### PR TITLE
refactor(webpack): remove livereload plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "ts-loader": "^0.7.2",
     "typescript": "^1.7.3",
     "webpack": "^1.12.9",
-    "webpack-dev-server": "^1.14.0",
-    "webpack-livereload-plugin": "^0.4.0"
+    "webpack-dev-server": "^1.14.0"
   },
   "dependencies": {
     "angular2": "2.0.0-alpha.48",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,3 @@
-var LiveReloadPlugin = require('webpack-livereload-plugin');
 var webpack = require('webpack');
 
 module.exports = {
@@ -12,10 +11,6 @@ module.exports = {
       'rxjs/operators/take': 'rxjs/operator/take'
     }
   },
-
-  plugins: [
-    new LiveReloadPlugin()
-  ],
 
   entry: './src/main.ts',
   output: {
@@ -36,7 +31,6 @@ module.exports = {
   },
 
   devServer: {
-    historyApiFallback: true,
-    hot: false
+    historyApiFallback: true
   }
 };


### PR DESCRIPTION
You don't need that `hot` config and you don't need that plugin to get reloading with the dev server (that is what `--inline` does).

So you can go to a complex url like `http://localhost:8080/webpack-dev-server/` to get livereloading or you can use `--inline` to add a script tag "on the fly" to fix it.