### PR TITLE
feat(build): treat index.html as a template

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple starter Angular2 project",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --colors --display-error-details --display-cached --port 8080 --content-base src"
+    "start": "webpack-dev-server --inline --colors --display-error-details --display-cached --port 8080 --content-base dist"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/angular/angular2-seed#readme",
   "devDependencies": {
+    "html-webpack-plugin": "^1.7.0",
     "ts-loader": "^0.7.2",
     "typescript": "^1.7.3",
     "webpack": "^1.12.9",

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,5 @@
 	<head></head>
 	<body>
 		<app>loading...</app>
-		<script src="bundle.js"></script>
 	</body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 var LiveReloadPlugin = require('webpack-livereload-plugin');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
 var webpack = require('webpack');
 
 module.exports = {
@@ -14,6 +15,10 @@ module.exports = {
   },
 
   plugins: [
+    new HtmlWebpackPlugin({
+      template: './src/index.html',
+      inject: 'body'
+    }),
     new LiveReloadPlugin()
   ],
 


### PR DESCRIPTION
This feature doesn't give too much right now, but will make much more sense after you add more features.

The idea is to treat the index.html as a template. The good point on it is that you remove all need of script tags (so it simpler and prettier).

Then when you add `scss` support (which is what I assume seeing your config), you can use another plugin to extract all the css within your bundle to create a separate `bundle.css` or something and that can be injected into the template automagically as well (so you don't need to add link tags by hand for prod).

Also, if you cache-bust your stuff (which is free with webpack), the generated index.html from this template will have the right path to the cache-busted files.