### PR TITLE
made npm scripts relatively platform independent

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "1.0.0",
   "description": "A simple starter Angular2 project",
   "scripts": {
-    "typings-install": "node_modules/typings/dist/bin.js install",
+    "typings-install": "node node_modules/typings/dist/bin.js install",
     "postinstall": "npm run typings-install",
-    "build": "node_modules/webpack/bin/webpack.js --inline --colors --progress --display-error-details --display-cached",
+    "build": "node node_modules/webpack/bin/webpack.js --inline --colors --progress --display-error-details --display-cached",
     "watch": "npm run build -- --watch",
-    "server": "node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --colors --progress --display-error-details --display-cached --port 3000  --content-base src",
+    "server": "node node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --colors --progress --display-error-details --display-cached --port 3000  --content-base src",
     "start": "npm run server"
   },
   "contributors": [


### PR DESCRIPTION
Fixes issue where the npm scripts fail to run from a non-cygwin environment. 

To recreate the issue (on a windows machine) try installing with `npm i`; the `post-install` script fails. Now (somehow) run the `post-install` stuff, and then try `npm start`. The latter will also fail with an error message saying `node_modules isn't a recognized command` or something like that...