### PR TITLE
removes semantic errors when starting

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,7 @@ gulp.task('clean', function(cb){
 
 //compile app typescript files
 gulp.task('compile:app', function(){
-  return gulp.src('src/**/*.ts')
+  return gulp.src(['src/**/*.ts', 'typings/browser/**/*.d.ts'])
     .pipe(ts(tsProject))
     .pipe(gulp.dest('./dist'))
     .pipe(connect.reload());


### PR DESCRIPTION
`gulp-typescript` requires definition files to be passed in as well and no definition related errors will be logged when running `npm start`