### PR TITLE
replaces es6-promise and es6-collections with es6-shim

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -3,8 +3,7 @@
   "version": false,
   "dependencies": {},
   "ambientDependencies": {
-    "es6-collections": "registry:dt/es6-collections#0.5.1+20160215162030",
-    "es6-promise": "registry:dt/es6-promise#0.0.0+20160221190517",
+    "es6-shim": "registry:dt/es6-shim#0.31.2+20160317120654",
     "node": "registry:dt/node#4.0.0+20160319033040"
   }
 }


### PR DESCRIPTION
es6-shim is also included according to angular.io docs and it has both collections and promises support