### PR TITLE
Added missing dev dependency "typings"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "gulp-watch": "^4.3.5",
     "systemjs": "^0.19.6",
     "systemjs-builder": "^0.14.11",
-    "typescript": "^1.7.3"
+    "typescript": "^1.7.3",
+    "typings": "^0.7.12"
   },
   "dependencies": {
     "angular2": "2.0.0-beta.16",


### PR DESCRIPTION
Following the usage instructions
 
  Clone or fork this repository (`git clone https://github.com/angular/angular2-seed.git --branch systemjs`)
  Make sure you have node.js installed
  run npm install to install dependencies

error: 
```
> typings install

sh: typings: command not found
```