### PR TITLE
"outDir" causes issues with how gulp uses files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "commonjs",
     "target": "es5",
     "noImplicitAny": false,
-    "outDir": "dist",
     "rootDir": ".",
     "sourceMap": false,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
@see https://github.com/ivogabe/gulp-typescript/issues/143

with "outDir" the following dist structure is created

```
angular2-seed git:(systemjs)>ls dist
app          bootstrap.js index.html   src          vendor
```

throws this error in the browser:
  `bootstrap.js:11 Error: SyntaxError: Unexpected token <(…)`

the bootstrap.js has:
```
System.import('./app.js')...
```
which implies the intent is to be in the same dir or at
the very least not in a src dir within the dist.

removing "outDir" in tsconfig.json, alleviates the issue

new dist
```
➜  angular2-seed git:(systemjs) ls dist
app          app.js       bootstrap.js index.html   vendor
```

now the usage instructions actually run