### PR TITLE
Making typings.json config compatible with Typings v1.x.x - solves #71

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -2,7 +2,7 @@
   "name": "angular2-seed",
   "version": false,
   "dependencies": {},
-  "ambientDependencies": {
+  "globalDependencies": {
     "es6-collections": "registry:dt/es6-collections#0.5.1+20160316155526",
     "es6-promise": "registry:dt/es6-promise#0.0.0+20160423074304",
     "node": "registry:dt/node#4.0.0+20160423143914"


### PR DESCRIPTION
Solves #71 (see https://github.com/angular/angular2-seed/issues/71#issuecomment-219818894).

npm _typings_ went up a major release and made [some breaking changes](https://github.com/typings/typings/releases/tag/v1.0.0). One of which is that they renamed _ambient_ to _global_, as in "**ambient**Dependencies" to "**global**Dependencies".

> * Many breaking changes (see https://github.com/typings/core/releases/tag/v1.0.0)
>    * **Renamed ambient to global**
>    * ...