### PR TITLE
add npm run typings-install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@ This branch uses [Webpack](https://webpack.github.io/) for Development. There is
 - Make sure you have [node.js](https://nodejs.org/) installed
 - run `npm install -g webpack webpack-dev-server typings typescript` to install global dependencies
 - run `npm install` to install dependencies
+- run `npm run typings-install` to install typings
 - run `npm start` to fire up dev server
 - open browser to [`http://localhost:3000`](http://localhost:3000)


### PR DESCRIPTION
It's not obvious from the readme that you should install typings separately and it results in typings errors in the console.  Installing them fixes that. 