### PR TITLE
docs(readme): remove npm run typings-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,5 @@ This branch uses [Webpack](https://webpack.github.io/) for Development. There is
 - Make sure you have [node.js](https://nodejs.org/) installed
 - run `npm install -g webpack webpack-dev-server typings typescript` to install global dependencies
 - run `npm install` to install dependencies
-- run `npm run typings-install` to install typings
 - run `npm start` to fire up dev server
 - open browser to [`http://localhost:3000`](http://localhost:3000)


### PR DESCRIPTION
npm run typings-install is already present in package.json and it runs before post install. so remove it from usage section of README.md file.