### PR TITLE
Upgrade awesome-typescript-loader (fixes #96)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "devDependencies": {
     "angular2-template-loader": "^0.4.0",
-    "awesome-typescript-loader": "~0.17.0",
+    "awesome-typescript-loader": "^1.1.1",
     "css-loader": "^0.23.1",
     "es6-promise": "3.0.2",
     "es6-shim": "0.35.0",


### PR DESCRIPTION
The old version of awesome-typescript-loader was causing an issue where
changes were being detected by the webpack-dev-server, but did not cause
typescript code to be recompiled. The latest version does work
correctly.