### PR TITLE
refactor: remove typings folder as it is not used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /node_modules/
 /dist/
 /npm-debug.log
-/typings/


### PR DESCRIPTION
Typings are managed by @types/<name> in package.json devDependencies.
This removes the need for checking the `/typings/` folder since it should no longer exist.
As per: https://blogs.msdn.microsoft.com/typescript/2016/06/15/the-future-of-declaration-files/