### PR TITLE
removed --cors from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "webpack --progress",
     "watch": "npm run build -- --watch",
-    "server": "webpack-dev-server --inline --progress --cors --port 3000 --content-base src",
+    "server": "webpack-dev-server --inline --progress --port 3000 --content-base src",
     "start": "npm run server"
   },
   "contributors": [


### PR DESCRIPTION
The "--cors" option is not recognized by webpack and consequently broke `npm start`.